### PR TITLE
Switch allowed from ceph -> charms_ceph

### DIFF
--- a/git_sync.py
+++ b/git_sync.py
@@ -44,7 +44,7 @@ def sync(src, dest, rename=None):
         logging.debug('Removing existing directory: %s' % dest)
         shutil.rmtree(dest)
 
-    allowed = ["ceph"]
+    allowed = ["charms_ceph"]
     for e in os.listdir(src):
         if e in allowed:
             logging.info('Syncing directory: %s -> %s.' % (e, dest))


### PR DESCRIPTION
This follows the recent rename of charms.ceph's parent python
package from ceph to charms_ceph.